### PR TITLE
Embla Carousel v9

### DIFF
--- a/.changeset/busy-tires-learn.md
+++ b/.changeset/busy-tires-learn.md
@@ -1,0 +1,10 @@
+---
+"embla-carousel-angular": major
+---
+
+Migrate the Angular wrapper to Embla Carousel `v9.0.0`.
+
+Breaking changes:
+- Rename wrapper methods `scrollTo`, `scrollPrev`, `scrollNext` to `goTo`, `goToPrev`, `goToNext`.
+- Align event names with Embla v9 lowercase event model and remove `init` usage.
+- Move `embla-carousel` to `peerDependencies`.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,8 @@
+{
+  "mode": "pre",
+  "tag": "next",
+  "initialVersions": {
+    "embla-carousel-angular": "21.0.0"
+  },
+  "changesets": []
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,22 +15,41 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install
 
+      - name: Resolve publish command
+        id: publish-cmd
+        run: |
+          PRE_TAG="$(node -e "const fs=require('node:fs'); try { const pre=JSON.parse(fs.readFileSync('.changeset/pre.json','utf8')); if (pre.mode === 'pre') process.stdout.write(pre.tag || 'next'); } catch {}")"
+
+          if [ -n "$PRE_TAG" ]; then
+            {
+              echo "command<<EOF"
+              echo "pnpm run build && changeset publish --tag $PRE_TAG"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo "command<<EOF"
+              echo "pnpm run release"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: pnpm run release
+          publish: ${{ steps.publish-cmd.outputs.command }}
           commit: "chore(release): publish"
           title: "chore(release): publish"
         env:

--- a/README.md
+++ b/README.md
@@ -22,8 +22,16 @@
 <h2 align="center">Installation</h2>
 
 ```shell
-npm i embla-carousel-angular
+npm i embla-carousel embla-carousel-angular
 ```
+
+<br>
+
+<h2 align="center">Breaking changes in Embla v9</h2>
+
+- `scrollTo`, `scrollPrev`, `scrollNext` were renamed to `goTo`, `goToPrev`, `goToNext`.
+- `EmblaEventType` values are now lowercase (`pointerdown`, `slidesinview`, `reinit`, ...).
+- `init` event is removed.
 
 <br>
 
@@ -94,15 +102,15 @@ The `emblaCarousel` directive takes the Embla Carousel [options](https://www.emb
 <br />
 
 - `emblaApi.on()`
-- `emblaApi.scrollNext()`
-- `emblaApi.scrollPrev()`
-- `emblaApi.scrollTo()`
+- `emblaApi.goToNext()`
+- `emblaApi.goToPrev()`
+- `emblaApi.goTo()`
 
 Consider using the following methods which are wrapped with `ngZone.runOutsideAngular()`:
 
-- `EmblaCarouselDirective.scrollPrev()`
-- `EmblaCarouselDirective.scrollNext()`
-- `EmblaCarouselDirective.scrollTo()`
+- `EmblaCarouselDirective.goToPrev()`
+- `EmblaCarouselDirective.goToNext()`
+- `EmblaCarouselDirective.goTo()`
 
 ```ts
 import { Component, effect, viewChild } from '@angular/core'
@@ -184,24 +192,32 @@ export class CarouselComponent {
   }
 
   public readonly subscribeToEvents: EmblaEventType[] = [
-    'init',
-    'pointerDown',
-    'pointerUp',
-    'slidesChanged',
-    'slidesInView',
+    'pointerdown',
+    'pointerup',
+    'slideschanged',
+    'slidesinview',
     'select',
     'settle',
     'destroy',
-    'reInit',
+    'reinit',
     'resize',
     'scroll'
   ]
 
-  onEmblaChanged(event: EmblaEventType): void {
+  onEmblaChange(event: EmblaEventType): void {
     console.log(`Embla event triggered: ${event}`)
   }
 }
 ```
+
+<h2 align="center">SSR guidance</h2>
+
+When using Angular Universal / SSR:
+
+- The directive only creates Embla in the browser, so `emblaApi` is `undefined` on the server.
+- Guard API calls with optional chaining or browser-only effects.
+- Use Embla v9 `options.ssr` to pre-compute snap positions for better first paint stability.
+- After client init, `emblaApi?.ssrStyles(containerSelector, slideSelector)` can be used to generate inline styles for SSR/hydration workflows if you need deterministic server/client layout.
 
 <h2 align="center">Adding plugins</h2>
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "test": "ng test",
     "lint": "ng lint",
     "release": "pnpm run build && changeset publish",
+    "release:pre:enter": "changeset pre enter next",
+    "release:pre:exit": "changeset pre exit",
+    "release:pre": "pnpm run build && changeset version && changeset publish --tag next",
     "changeset": "changeset",
     "prepare": "simple-git-hooks"
   },
@@ -25,6 +28,7 @@
     "@angular/platform-browser": "^21.0.1",
     "@angular/platform-browser-dynamic": "^21.0.1",
     "@angular/router": "^21.0.1",
+    "embla-carousel": "^9.0.0-rc01",
     "embla-carousel-angular": "workspace:*",
     "rxjs": "~7.8.2",
     "tslib": "^2.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@angular/router':
         specifier: ^21.0.1
         version: 21.0.1(@angular/common@21.0.1(@angular/core@21.0.1(@angular/compiler@21.0.1)(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@21.0.1(@angular/compiler@21.0.1)(rxjs@7.8.2)(zone.js@0.15.0))(@angular/platform-browser@21.0.1(@angular/animations@21.0.1(@angular/core@21.0.1(@angular/compiler@21.0.1)(rxjs@7.8.2)(zone.js@0.15.0)))(@angular/common@21.0.1(@angular/core@21.0.1(@angular/compiler@21.0.1)(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@21.0.1(@angular/compiler@21.0.1)(rxjs@7.8.2)(zone.js@0.15.0)))(rxjs@7.8.2)
+      embla-carousel:
+        specifier: '>=9.0.0-rc01 <10.0.0'
+        version: 9.0.0-rc01
       embla-carousel-angular:
         specifier: workspace:*
         version: link:projects/embla-carousel-angular/dist
@@ -115,11 +118,11 @@ importers:
         specifier: '>=21.0.0'
         version: 21.0.1(@angular/compiler@21.0.1)(rxjs@7.8.2)(zone.js@0.15.0)
       embla-carousel:
-        specifier: ^8.6.0
-        version: 8.6.0
+        specifier: '>=9.0.0-rc01 <10.0.0'
+        version: 9.0.0-rc01
       embla-carousel-reactive-utils:
-        specifier: ^8.6.0
-        version: 8.6.0(embla-carousel@8.6.0)
+        specifier: ^9.0.0-rc01
+        version: 9.0.0-rc01(embla-carousel@9.0.0-rc01)
       tslib:
         specifier: ^2.3.0
         version: 2.8.1
@@ -2513,13 +2516,13 @@ packages:
   electron-to-chromium@1.5.262:
     resolution: {integrity: sha512-NlAsMteRHek05jRUxUR0a5jpjYq9ykk6+kO0yRaMi5moe7u0fVIOeQ3Y30A8dIiWFBNUoQGi1ljb1i5VtS9WQQ==}
 
-  embla-carousel-reactive-utils@8.6.0:
-    resolution: {integrity: sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==}
+  embla-carousel-reactive-utils@9.0.0-rc01:
+    resolution: {integrity: sha512-RnW0NMrL7wVAQb9jro+l96hLI2JairyFHS2Jv+fvXakveD/c5aD9aoNH94YRbTmi0G7PxrKSxydmCpTy5eFmrA==}
     peerDependencies:
-      embla-carousel: 8.6.0
+      embla-carousel: 9.0.0-rc01
 
-  embla-carousel@8.6.0:
-    resolution: {integrity: sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==}
+  embla-carousel@9.0.0-rc01:
+    resolution: {integrity: sha512-4BTERU1gAXgg4Vl0m7hQ1GzePGLNNfM2j030ww8i9idiPXumyRUpaNUDfT2zx1Hv8um1Ew7QKBy/HdNPz8L30g==}
 
   emoji-regex@10.3.0:
     resolution: {integrity: sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==}
@@ -6893,11 +6896,11 @@ snapshots:
 
   electron-to-chromium@1.5.262: {}
 
-  embla-carousel-reactive-utils@8.6.0(embla-carousel@8.6.0):
+  embla-carousel-reactive-utils@9.0.0-rc01(embla-carousel@9.0.0-rc01):
     dependencies:
-      embla-carousel: 8.6.0
+      embla-carousel: 9.0.0-rc01
 
-  embla-carousel@8.6.0: {}
+  embla-carousel@9.0.0-rc01: {}
 
   emoji-regex@10.3.0: {}
 

--- a/projects/embla-carousel-angular/README.md
+++ b/projects/embla-carousel-angular/README.md
@@ -16,8 +16,16 @@
 <h2 align="center">Installation</h2>
 
 ```shell
-npm i embla-carousel-angular
+npm i embla-carousel embla-carousel-angular
 ```
+
+<br>
+
+<h2 align="center">Breaking changes in Embla v9</h2>
+
+- `scrollTo`, `scrollPrev`, `scrollNext` were renamed to `goTo`, `goToPrev`, `goToNext`.
+- `EmblaEventType` values are now lowercase (`pointerdown`, `slidesinview`, `reinit`, ...).
+- `init` event is removed.
 
 <br>
 
@@ -89,15 +97,15 @@ The `emblaCarousel` directive takes the Embla Carousel [options](https://www.emb
 <br />
 
 - `emblaApi.on()`
-- `emblaApi.scrollNext()`
-- `emblaApi.scrollPrev()`
-- `emblaApi.scrollTo()`
+- `emblaApi.goToNext()`
+- `emblaApi.goToPrev()`
+- `emblaApi.goTo()`
 
 Consider using the following methods which are wrapped with `ngZone.runOutsideAngular()`:
 
-- `EmblaCarouselDirective.scrollPrev()`
-- `EmblaCarouselDirective.scrollNext()`
-- `EmblaCarouselDirective.scrollTo()`
+- `EmblaCarouselDirective.goToPrev()`
+- `EmblaCarouselDirective.goToNext()`
+- `EmblaCarouselDirective.goTo()`
 
 ```ts
 import { Component, effect, viewChild } from '@angular/core'
@@ -179,24 +187,32 @@ export class CarouselComponent {
   }
   
   public readonly subscribeToEvents: EmblaEventType[] = [
-    'init',
-    'pointerDown',
-    'pointerUp',
-    'slidesChanged',
-    'slidesInView',
+    'pointerdown',
+    'pointerup',
+    'slideschanged',
+    'slidesinview',
     'select',
     'settle',
     'destroy',
-    'reInit',
+    'reinit',
     'resize',
     'scroll'
   ]
 
-  onEmblaChanged(event: EmblaEventType): void {
+  onEmblaChange(event: EmblaEventType): void {
     console.log(`Embla event triggered: ${event}`)
   }
 }
 ```
+
+<h2 align="center">SSR guidance</h2>
+
+When using Angular Universal / SSR:
+
+- The directive only creates Embla in the browser, so `emblaApi` is `undefined` on the server.
+- Guard API calls with optional chaining or browser-only effects.
+- Use Embla v9 `options.ssr` to pre-compute snap positions for better first paint stability.
+- After client init, `emblaApi?.ssrStyles(containerSelector, slideSelector)` can be used to generate inline styles for SSR/hydration workflows if you need deterministic server/client layout.
 
 <h2 align="center">Adding plugins</h2>
 

--- a/projects/embla-carousel-angular/package.json
+++ b/projects/embla-carousel-angular/package.json
@@ -28,11 +28,11 @@
   ],
   "peerDependencies": {
     "@angular/common": ">=21.0.0",
-    "@angular/core": ">=21.0.0"
+    "@angular/core": ">=21.0.0",
+    "embla-carousel": ">=9.0.0-0"
   },
   "dependencies": {
-    "embla-carousel": "^8.6.0",
-    "embla-carousel-reactive-utils": "^8.6.0",
+    "embla-carousel-reactive-utils": "^9.0.0-rc01",
     "tslib": "^2.3.0"
   },
   "publishConfig": {

--- a/projects/embla-carousel-angular/src/lib/utils.ts
+++ b/projects/embla-carousel-angular/src/lib/utils.ts
@@ -8,6 +8,10 @@ EmblaOptionsType | undefined
   factory: () => undefined,
 })
 
+export function canUseDOM(): boolean {
+  return typeof window !== 'undefined' && typeof document !== 'undefined'
+}
+
 export function provideEmblaGlobalOptions(
   options?: EmblaOptionsType,
 ): Provider[] {

--- a/src/app/components/carousel/carousel.component.html
+++ b/src/app/components/carousel/carousel.component.html
@@ -20,14 +20,14 @@
   </div>
 
   <div class="embla__buttons">
-    <button class="embla__button embla__button--prev" [disabled]="!prevBtnEnabled()" (click)="scrollPrev()">
+    <button class="embla__button embla__button--prev" [disabled]="!prevBtnEnabled()" (click)="goToPrev()">
       <svg class="embla__button__svg" viewBox="137.718 -1.001 366.563 644">
         <path
           d="M428.36 12.5c16.67-16.67 43.76-16.67 60.42 0 16.67 16.67 16.67 43.76 0 60.42L241.7 320c148.25 148.24 230.61 230.6 247.08 247.08 16.67 16.66 16.67 43.75 0 60.42-16.67 16.66-43.76 16.67-60.42 0-27.72-27.71-249.45-249.37-277.16-277.08a42.308 42.308 0 0 1-12.48-30.34c0-11.1 4.1-22.05 12.48-30.42C206.63 234.23 400.64 40.21 428.36 12.5z"
         />
       </svg>
     </button>
-    <button class="embla__button embla__button--next" [disabled]="!nextBtnEnabled()" (click)="scrollNext()">
+    <button class="embla__button embla__button--next" [disabled]="!nextBtnEnabled()" (click)="goToNext()">
       <svg class="embla__button__svg" viewBox="0 0 238.003 238.003">
         <path
           d="M181.776 107.719L78.705 4.648c-6.198-6.198-16.273-6.198-22.47 0s-6.198 16.273 0 22.47l91.883 91.883-91.883 91.883c-6.198 6.198-6.198 16.273 0 22.47s16.273 6.198 22.47 0l103.071-103.039a15.741 15.741 0 0 0 4.64-11.283c0-4.13-1.526-8.199-4.64-11.313z"
@@ -42,7 +42,7 @@
     <button
       [ngClass]="'embla__dot'.concat($index === selectedIndex() ? ' embla__dot--selected' : '')"
       type="button"
-      (click)="scrollTo($index)"
+      (click)="goTo($index)"
     ></button>
   }
 </div>

--- a/src/app/components/carousel/carousel.component.ts
+++ b/src/app/components/carousel/carousel.component.ts
@@ -2,6 +2,8 @@ import { CommonModule } from '@angular/common'
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
+  effect,
   input,
   signal,
   viewChild,
@@ -29,34 +31,40 @@ export class CarouselComponent {
   prevBtnEnabled = signal(false)
   nextBtnEnabled = signal(false)
   selectedIndex = signal(0)
-  scrollSnaps = signal<number[]>([])
-  subscribeToEvents: EmblaEventType[] = ['init', 'reInit', 'select', 'scroll']
+  emblaApi = computed(() => this.emblaRef()?.emblaApiSignal())
+  scrollSnaps = computed(() => this.emblaApi()?.snapList())
+  subscribeToEvents: EmblaEventType[] = ['reinit', 'select', 'scroll']
+
+  constructor() {
+    effect(() => {
+      const embla = this.emblaApi()
+      if (embla) {
+        this.onEmblaChange('reinit', embla)
+      }
+    })
+  }
 
   imageByIndex(index: number) {
     return `/assets/images/slide-${index}.jpg`
   }
 
-  scrollPrev() {
-    this.emblaRef()?.scrollPrev()
+  goToPrev() {
+    this.emblaRef()?.goToPrev()
   }
 
-  scrollNext() {
-    this.emblaRef()?.scrollNext()
+  goToNext() {
+    this.emblaRef()?.goToNext()
   }
 
-  scrollTo(index: number) {
-    this.emblaRef()?.scrollTo(index)
+  goTo(index: number) {
+    this.emblaRef()?.goTo(index)
   }
 
   onEmblaChange(type: EmblaEventType, emblaApi: EmblaCarouselType) {
-    if (type === 'init') {
-      this.scrollSnaps.set(emblaApi.scrollSnapList())
-    }
-
-    if (type === 'select' || type === 'init' || type === 'reInit') {
-      this.selectedIndex.set(emblaApi.selectedScrollSnap())
-      this.prevBtnEnabled.set(emblaApi.canScrollPrev())
-      this.nextBtnEnabled.set(emblaApi.canScrollNext())
+    if (type === 'select' || type === 'reinit') {
+      this.selectedIndex.set(emblaApi.selectedSnap())
+      this.prevBtnEnabled.set(emblaApi.canGoToPrev())
+      this.nextBtnEnabled.set(emblaApi.canGoToNext())
       return
     }
   }


### PR DESCRIPTION
migrate Angular wrapper to Embla Carousel v9.0.0 with breaking changes.

- Rename wrapper methods `scrollTo`, `scrollPrev`, `scrollNext` to `goTo`, `goToPrev`, `goToNext`.
- Align event names with Embla v9 lowercase event model and remove `init` usage.
- Move `embla-carousel` to `peerDependencies`.